### PR TITLE
ci: bump hello-api image to 164131305a39364c349bf5e457e55bc0baeef2c9

### DIFF
--- a/charts/hello-api/values.yaml
+++ b/charts/hello-api/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/tylermac92/hello-api
-  tag: "ee325748d0e748e28c7e8d66d7dc622487b60888"
+  tag: "164131305a39364c349bf5e457e55bc0baeef2c9"
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
Automated bump of hello-api image tag via CI