### PR TITLE
ci: bump hello-api image to 0a367e2f49101c011c39ba60ab0e79901d36dc4d

### DIFF
--- a/charts/hello-api/values.yaml
+++ b/charts/hello-api/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/tylermac92/hello-api
-  tag: "cadc97a959cb63d95e6d5621d1d5e6a89efe63a1"
+  tag: "0a367e2f49101c011c39ba60ab0e79901d36dc4d"
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
Automated bump of hello-api image tag via CI