### PR TITLE
ci: bump hello-api image to 597729fc946927aa23378a87a7a7eb544ed47451

### DIFF
--- a/charts/hello-api/values.yaml
+++ b/charts/hello-api/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/tylermac92/hello-api
-  tag: "34a7c3145bab2e1d0be4973f84fbd140c6ba7ced"
+  tag: "597729fc946927aa23378a87a7a7eb544ed47451"
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
Automated bump of hello-api image tag via CI